### PR TITLE
MW-245: Add info about filters in the 'Convert to Order' screen

### DIFF
--- a/src/requisition-convert-to-order/convert-to-order.html
+++ b/src/requisition-convert-to-order/convert-to-order.html
@@ -1,9 +1,10 @@
 <h2>{{'requisitionConvertToOrder.convertRequisitionsToOrder' | message}}</h2>
 <section class="openlmis-table-container">
 	<form ng-submit="vm.search()">
-		<label for="searchFor">{{'requisitionConvertToOrder.search' | message}}</label>
+		<label for="searchFor">{{'requisitionConvertToOrder.filter' | message}}</label>
 		<input id="searchFor" type="text" ng-model="vm.filterValue"
-			   maxlength="50"/>
+			   maxlength="50" aria-labelledby="filtersInfo"/>
+		<p class="filters-info" id="filtersInfo">{{'requisitionConvertToOrder.info' | message}}</p>
 		<input type="submit" value="{{'requisitionConvertToOrder.search' | message}}"/>
 	</form>
 	<table>

--- a/src/requisition-convert-to-order/convert-to-order.scss
+++ b/src/requisition-convert-to-order/convert-to-order.scss
@@ -1,0 +1,3 @@
+.filters-info {
+  font-style: italic;
+}

--- a/src/requisition-convert-to-order/messages_en.json
+++ b/src/requisition-convert-to-order/messages_en.json
@@ -12,6 +12,8 @@
     "requisitionConvertToOrder.facility": "Facility",
     "requisitionConvertToOrder.facilityCode": "Facility code",
     "requisitionConvertToOrder.facilityName": "Facility name",
+    "requisitionConvertToOrder.filter": "Filter",
+    "requisitionConvertToOrder.info": "In order to filter requisitions type in one of the following parameters: Program Name, Facility Name or Facility Code and click \"Search\" button.",
     "requisitionConvertToOrder.noRequisitionToConvert": "No requisitions to be converted to orders",
     "requisitionConvertToOrder.noSearchResults": "No search results",
     "requisitionConvertToOrder.noSupplyingDepotSelected": "Supplying depot not selected",


### PR DESCRIPTION
Users testing application were not aware of the fact that they can filter requisitions by facilities/programs in this screen - I've added more information to make it clear (ticket from Malawi implementation - MW-245, but it was also decided that we should contribute this change to the core project).