### PR TITLE
Add 'REJECTED' requisition status support

### DIFF
--- a/src/requisition-constants/requisition-status.constant.js
+++ b/src/requisition-constants/requisition-status.constant.js
@@ -38,6 +38,7 @@
             APPROVED: 'APPROVED',
             RELEASED: 'RELEASED',
             SKIPPED: 'SKIPPED',
+            REJECTED: 'REJECTED',
             $toList: toList,
             $getDisplayName: getDisplayName
         };
@@ -89,6 +90,8 @@
                 displayName = 'Released';
             } else if (status == this.SKIPPED) {
                 displayName = 'Skipped';
+            } else if (status == this.REJECTED) {
+                displayName = 'Rejected';
             }
             return displayName;
         }

--- a/src/requisition-constants/requisition-status.constant.spec.js
+++ b/src/requisition-constants/requisition-status.constant.spec.js
@@ -69,6 +69,12 @@ describe("REQUISITION_STATUS", function() {
 
             expect(displayName).toBe('Skipped');
         });
+
+        it('should get display name for REJECTED status', function() {
+            var displayName = RequisitionStatus.$getDisplayName('REJECTED');
+
+            expect(displayName).toBe('Rejected');
+        });
     });
 
     describe('toList', function() {
@@ -83,6 +89,7 @@ describe("REQUISITION_STATUS", function() {
             expect(returnedList[4].label).toBe('APPROVED');
             expect(returnedList[5].label).toBe('RELEASED');
             expect(returnedList[6].label).toBe('SKIPPED');
+            expect(returnedList[7].label).toBe('REJECTED');
         });
     });
 });

--- a/src/requisition-full-supply/full-supply.controller.js
+++ b/src/requisition-full-supply/full-supply.controller.js
@@ -118,7 +118,7 @@
          * Checks if the current requisition template has a skip column, and if the requisition state allows for skipping.
          */
         function areSkipControlsVisible(){
-            if(!requisition.$isSubmitted() && !requisition.$isInitiated()){
+            if(!requisition.$isSubmitted() && !requisition.$isInitiated() && !requisition.$isRejected()){
                 return false;
             }
 

--- a/src/requisition-full-supply/full-supply.controller.spec.js
+++ b/src/requisition-full-supply/full-supply.controller.spec.js
@@ -34,38 +34,26 @@ describe('FullSupplyController', function() {
     });
 
     beforeEach(function($rootScope) {
-        requisition = {
-            template: jasmine.createSpyObj('RequisitionTemplate', ['getColumns']),
-            requisitionLineItems: [
-                lineItem('One', true),
-                lineItem('Two', true),
-                lineItem('One', true),
-                lineItem('Two', true),
-                lineItem('Three', false)
-            ]
-        };
+        requisition = jasmine.createSpyObj('requisition', ['$isInitiated', '$isSubmitted','$isRejected']);
+        requisition.template = jasmine.createSpyObj('RequisitionTemplate', ['getColumns']);
+        requisition.requisitionLineItems = [
+            lineItem('One', true),
+            lineItem('Two', true),
+            lineItem('One', true),
+            lineItem('Two', true),
+            lineItem('Three', false)
+        ];
 
         lineItems = [
             requisition.requisitionLineItems[0],
             requisition.requisitionLineItems[1],
             requisition.requisitionLineItems[2],
-            requisition.requisitionLineItems[3],
+            requisition.requisitionLineItems[3]
         ];
 
-        requisitionStatus = "INITIALIZED";
-
-        requisition.$isSubmitted = function(){
-            if(requisitionStatus == "SUBMITTED"){
-                return true;
-            }
-            return false;
-        }
-        requisition.$isInitiated = function(){
-            if(requisitionStatus == "INITIALIZED"){
-                return true;
-            }
-            return false;
-        }
+        requisition.$isInitiated.andReturn(false);
+        requisition.$isSubmitted.andReturn(false);
+        requisition.$isRejected.andReturn(false);
 
         columns = [{
             name: 'skipped'
@@ -131,27 +119,37 @@ describe('FullSupplyController', function() {
         expect(requisition.requisitionLineItems[4].skipped).toBe(false);
     });
 
-    it('should only show skip controls if the requistions status is INITIALIZED or SUBMITTED', function(){
-        // requisition status is INITIALIZED
-        expect(vm.areSkipControlsVisible()).toBe(true);
-
-        requisitionStatus = "SUBMITTED";
-        expect(vm.areSkipControlsVisible()).toBe(true);
-
-        requisitionStatus = "AUTHORIZED";
-        expect(vm.areSkipControlsVisible()).toBe(false);
-
-        requisitionStatus = "foo";
+    it('should not show skip controls', function(){
         expect(vm.areSkipControlsVisible()).toBe(false);
     });
 
-    it('should only show skip controls if the requisition template has a skip columm', function(){
-        // There is a column named skip
+    it('should show skip controls if the requistions status is INITIATED', function(){
+        requisition.$isInitiated.andReturn(true);
         expect(vm.areSkipControlsVisible()).toBe(true);
+    });
 
+    it('should show skip controls if the requistions status is SUBMITTED', function(){
+        requisition.$isSubmitted.andReturn(true);
+        expect(vm.areSkipControlsVisible()).toBe(true);
+    });
+
+    it('should show skip controls if the requistions status is REJECTED', function(){
+        requisition.$isRejected.andReturn(true);
+        expect(vm.areSkipControlsVisible()).toBe(true);
+    });
+
+    it('should show skip controls if the requisition template has a skip columm', function(){
+        requisition.$isInitiated.andReturn(true);
+        columns[0].name = 'skipped';
+
+        expect(vm.areSkipControlsVisible()).toBe(true);
+    });
+
+
+    it('should not show skip controls if the requisition template doesnt have a skip columm', function(){
+        requisition.$isInitiated.andReturn(true);
         columns[0].name = 'foo';
 
         expect(vm.areSkipControlsVisible()).toBe(false);
     });
-
 });

--- a/src/requisition-initiate/period.factory.js
+++ b/src/requisition-initiate/period.factory.js
@@ -58,7 +58,7 @@
                 program: programId,
                 facility: facilityId,
                 emergency: emergency,
-                requisitionStatus: emergency ? [REQUISITION_STATUS.INITIATED, REQUISITION_STATUS.SUBMITTED] : undefined
+                requisitionStatus: emergency ? [REQUISITION_STATUS.INITIATED, REQUISITION_STATUS.SUBMITTED, REQUISITION_STATUS.REJECTED] : undefined
             }));
 
             $q.all(promises).then(function(response) {

--- a/src/requisition-initiate/period.factory.spec.js
+++ b/src/requisition-initiate/period.factory.spec.js
@@ -87,7 +87,7 @@ describe('periodFactory', function() {
                 emergency: emergency,
                 facility: facilityId,
                 program: programId,
-                requisitionStatus: [REQUISITION_STATUS.INITIATED, REQUISITION_STATUS.SUBMITTED]
+                requisitionStatus: [REQUISITION_STATUS.INITIATED, REQUISITION_STATUS.SUBMITTED, REQUISITION_STATUS.REJECTED]
             });
         });
 

--- a/src/requisition-view/requisition-view.controller.js
+++ b/src/requisition-view/requisition-view.controller.js
@@ -385,7 +385,7 @@
          * @return {Boolean} should submit button be displayed
          */
         function displaySubmit() {
-            return (vm.requisition.$isInitiated() || vm.requisition.$isRejected) && hasRightForProgram(REQUISITION_RIGHTS.REQUISITION_CREATE);
+            return (vm.requisition.$isInitiated() || vm.requisition.$isRejected()) && hasRightForProgram(REQUISITION_RIGHTS.REQUISITION_CREATE);
         }
 
         /**

--- a/src/requisition-view/requisition-view.controller.js
+++ b/src/requisition-view/requisition-view.controller.js
@@ -385,7 +385,7 @@
          * @return {Boolean} should submit button be displayed
          */
         function displaySubmit() {
-            return vm.requisition.$isInitiated() && hasRightForProgram(REQUISITION_RIGHTS.REQUISITION_CREATE);
+            return (vm.requisition.$isInitiated() || vm.requisition.$isRejected) && hasRightForProgram(REQUISITION_RIGHTS.REQUISITION_CREATE);
         }
 
         /**
@@ -417,7 +417,7 @@
          */
         function displayDelete() {
             if (hasRightForProgram(REQUISITION_RIGHTS.REQUISITION_DELETE)) {
-                if (vm.requisition.$isInitiated()) {
+                if (vm.requisition.$isInitiated() || vm.requisition.$isRejected()) {
                     return hasRightForProgram(REQUISITION_RIGHTS.REQUISITION_CREATE);
                 }
                 if (vm.requisition.$isSubmitted()) {
@@ -454,7 +454,7 @@
          * @return {Boolean} true if skip button should be visible, false otherwise
          */
         function displaySkip() {
-            return vm.requisition.$isInitiated() &&
+            return (vm.requisition.$isInitiated() || vm.requisition.$isRejected()) &&
                 vm.requisition.program.periodsSkippable &&
                 !vm.requisition.emergency &&
                 hasRightForProgram(REQUISITION_RIGHTS.REQUISITION_CREATE);
@@ -472,7 +472,7 @@
          * @return {Boolean} true if sync button should be visible, false otherwise
          */
         function displaySync() {
-            if (vm.requisition.$isInitiated()) {
+            if (vm.requisition.$isInitiated() || vm.requisition.$isRejected()) {
                 return hasRightForProgram(REQUISITION_RIGHTS.REQUISITION_CREATE);
             }
             if (vm.requisition.$isSubmitted()) {

--- a/src/requisition-view/requisition-view.controller.spec.js
+++ b/src/requisition-view/requisition-view.controller.spec.js
@@ -77,7 +77,7 @@ describe('RequisitionViewController', function() {
 
             deferred = $q.defer();
             requisition = jasmine.createSpyObj('requisition',
-                ['$skip', '$isInitiated', '$isSubmitted', '$isAuthorized', '$isInApproval', '$isReleased', '$save', '$authorize', '$submit', '$remove', '$approve', '$reject']);
+                ['$skip', '$isInitiated', '$isSubmitted', '$isAuthorized', '$isInApproval', '$isReleased', '$isRejected', '$save', '$authorize', '$submit', '$remove', '$approve', '$reject']);
             requisition.id = '1';
             requisition.program = {
                 id: '2',
@@ -86,6 +86,7 @@ describe('RequisitionViewController', function() {
             };
             requisition.$isInitiated.andReturn(true);
             requisition.$isReleased.andReturn(false);
+            requisition.$isRejected.andReturn(false);
             requisition.$skip.andReturn(deferred.promise);
             requisition.$save.andReturn(deferred.promise);
             requisition.$authorize.andReturn(deferred.promise);
@@ -120,6 +121,14 @@ describe('RequisitionViewController', function() {
 
     it('should display skip button', function() {
         authorizationServiceSpy.hasRight.andReturn(true);
+        expect(vm.displaySkip()).toBe(true);
+    });
+
+    it('should display skip button when requisition is rejected', function() {
+        authorizationServiceSpy.hasRight.andReturn(true);
+        requisition.$isInitiated.andReturn(false);
+        requisition.$isRejected.andReturn(true);
+
         expect(vm.displaySkip()).toBe(true);
     });
 
@@ -195,6 +204,18 @@ describe('RequisitionViewController', function() {
         expect(vm.displaySync()).toBe(true);
     });
 
+    it('should display sync button when rejected', function() {
+        authorizationServiceSpy.hasRight.andReturn(true);
+
+        vm.requisition.$isInitiated.andReturn(false);
+        vm.requisition.$isSubmitted.andReturn(false);
+        vm.requisition.$isAuthorized.andReturn(false);
+        vm.requisition.$isInApproval.andReturn(false);
+        vm.requisition.$isRejected.andReturn(true);
+
+        expect(vm.displaySync()).toBe(true);
+    });
+
     it('should display sync button when submitted', function() {
         authorizationServiceSpy.hasRight.andReturn(true);
 
@@ -243,6 +264,16 @@ describe('RequisitionViewController', function() {
 
         expect(vm.displayDelete()).toBe(true);
     });
+
+    it('should display delete button when rejected', function() {
+        authorizationServiceSpy.hasRight.andReturn(true);
+
+        vm.requisition.$isInitiated.andReturn(false);
+        vm.requisition.$isRejected.andReturn(true);
+
+        expect(vm.displayDelete()).toBe(true);
+    });
+
 
     it('should display delete button when submitted', function() {
         authorizationServiceSpy.hasRight.andReturn(true);

--- a/src/requisition/requisition.js
+++ b/src/requisition/requisition.js
@@ -80,6 +80,7 @@
         Requisition.prototype.$isAuthorized = isAuthorized;
         Requisition.prototype.$isInApproval = isInApproval;
         Requisition.prototype.$isReleased = isReleased;
+        Requisition.prototype.$isRejected = isRejected;
         Requisition.prototype.$isAfterAuthorize = isAfterAuthorize;
         Requisition.prototype.$getProducts = getProducts;
 
@@ -339,6 +340,21 @@
          */
         function isReleased() {
             return this.status === REQUISITION_STATUS.RELEASED;
+        }
+
+        /**
+         * @ngdoc method
+         * @methodOf requisition.Requisition
+         * @name isRejected
+         *
+         * @description
+         * Responsible for checking if requisition is rejected.
+         * Returns true only if requisition status equals rejected.
+         *
+         * @return {Boolean} is requisition rejected
+         */
+        function isRejected() {
+            return this.status === REQUISITION_STATUS.REJECTED;
         }
 
        /**

--- a/src/requisition/requisition.spec.js
+++ b/src/requisition/requisition.spec.js
@@ -415,6 +415,22 @@ describe('Requisition', function() {
         expect(isReleased).toBe(false);
     });
 
+    it('should return true if requisition status is rejected', function() {
+        requisition.status = REQUISITION_STATUS.REJECTED;
+
+        var isRejected = requisition.$isRejected();
+
+        expect(isRejected).toBe(true);
+    });
+
+    it('should return false if requisition status is not rejected', function() {
+        requisition.status = REQUISITION_STATUS.INITIATED;
+
+        var isRejected = requisition.$isRejected();
+
+        expect(isRejected).toBe(false);
+    });
+
     describe('isAfterAuthorize', function() {
         it('should return false for requisition status INITIATED', function() {
             requisition.status = REQUISITION_STATUS.INITIATED;


### PR DESCRIPTION
The rejected state is basically the same as the initiated state
and is used merely to let users know that the requisition has
already been reviewed by a supervisor, has been rejected and
requires changes before re-submitting.