### PR TITLE
OLMIS-7638: fixed 'Facilities is still possible to select after being disabled'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 New functionality added in a backwards-compatible manner:
 * [TZUP-274](https://openlmis.atlassian.net/browse/TZUP-274): Added UI for requisition report only flag in requisition template.
 
+Bug fixes:
+* [OLMIS-7638](https://openlmis.atlassian.net/browse/OLMIS-7638): Fix error related to 'Facilities is still possible to select after being disabled'
+
 7.0.8 / 2022-10-07
 ==================
 

--- a/src/requisition-initiate/requisition-initiate.routes.js
+++ b/src/requisition-initiate/requisition-initiate.routes.js
@@ -56,6 +56,9 @@
                         );
                     }
                     return false;
+                },
+                permissions: function(permissionService) {
+                    return permissionService.empty();
                 }
             }
         });


### PR DESCRIPTION
TICKET: https://openlmis.atlassian.net/browse/OLMIS-7638

Presentation of fix according to reproduction step: 
![Peek 2023-02-21 16-59](https://user-images.githubusercontent.com/52816247/220399379-4715202e-dc4a-454a-bbff-e1926f6de18b.gif)

Fix depends on forcing reloading 'permission' to not take the ones from cache but from API hence this fix should return the actual state of available facilities. 