### PR TITLE
OLMIS-7625: Added unfinished=true query param to periodsForInitiate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ New functionality added in a backwards-compatible manner:
 Bug fixes:
 * [OLMIS-7638](https://openlmis.atlassian.net/browse/OLMIS-7638): Fix error related to 'Facilities is still possible to select after being disabled'
 * [OLMIS-7697](https://openlmis.atlassian.net/browse/OLMIS-7697): Added requisition report only when initializing the requisition template to fix save requisition Template properly.
+* [OLMIS-7625](https://openlmis.atlassian.net/browse/OLMIS-7625): Fixed setting Start Date for a specific program in a specific facility.
 
 7.0.8 / 2022-10-07
 ==================

--- a/src/requisition-initiate/period.service.js
+++ b/src/requisition-initiate/period.service.js
@@ -63,7 +63,8 @@
             return resource.periodsForInitiate({
                 programId: programId,
                 facilityId: facilityId,
-                emergency: emergency
+                emergency: emergency,
+                unfinished: true
             }).$promise.catch(function(response) {
                 if (response.status === 400) {
                     var data = angular.fromJson(response.data);

--- a/src/requisition-initiate/period.service.spec.js
+++ b/src/requisition-initiate/period.service.spec.js
@@ -69,7 +69,7 @@ describe('periodService', function() {
 
         it('should return promise', function() {
             $httpBackend.when('GET', requisitionUrlFactoryMock('/api/requisitions/periodsForInitiate?emergency=' +
-                emergency + '&facilityId=' + facilityId + '&programId=' + programId))
+                emergency + '&facilityId=' + facilityId + '&programId=' + programId + '&unfinished=' + true))
                 .respond(200, [periodOne, periodTwo]);
 
             promise = periodService.getPeriodsForInitiate(programId, facilityId, emergency);
@@ -81,7 +81,7 @@ describe('periodService', function() {
 
         it('should return proper response', function() {
             $httpBackend.when('GET', requisitionUrlFactoryMock('/api/requisitions/periodsForInitiate?emergency=' +
-                emergency + '&facilityId=' + facilityId + '&programId=' + programId))
+                emergency + '&facilityId=' + facilityId + '&programId=' + programId + '&unfinished=' + true))
                 .respond(200, [periodOne, periodTwo]);
 
             promise = periodService.getPeriodsForInitiate(programId, facilityId, emergency);
@@ -102,7 +102,7 @@ describe('periodService', function() {
 
         it('should call date utils', function() {
             $httpBackend.when('GET', requisitionUrlFactoryMock('/api/requisitions/periodsForInitiate?emergency=' +
-                emergency + '&facilityId=' + facilityId + '&programId=' + programId))
+                emergency + '&facilityId=' + facilityId + '&programId=' + programId + '&unfinished=' + true))
                 .respond(200, [periodOne, periodTwo]);
 
             promise = periodService.getPeriodsForInitiate(programId, facilityId, emergency);
@@ -117,7 +117,7 @@ describe('periodService', function() {
 
         it('should show an alert if facility is not supported', function() {
             $httpBackend.when('GET', requisitionUrlFactoryMock('/api/requisitions/periodsForInitiate?emergency=' +
-                emergency + '&facilityId=' + facilityId + '&programId=' + programId))
+                emergency + '&facilityId=' + facilityId + '&programId=' + programId + '&unfinished=' + true))
                 .respond(400, {
                     messageKey: 'requisition.error.facilityDoesNotSupportProgram'
                 });


### PR DESCRIPTION
On the backend, for the api/requisitions/periodsForInitiate endpoint, I added an optional query param 'unfinished', when it is set to true, only periods whose start date is equal to or later than the start date of the program are returned, which is exactly what we need in this case.

Jira task link: https://openlmis.atlassian.net/browse/OLMIS-7625
Related PR: https://github.com/OpenLMIS/openlmis-requisition/pull/63