### PR TITLE
OPSD-38: Added back the validation for stock on hand column for report only requisition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 7.0.14-SNAPSHOT / WIP
 ==================
 Bug fixes:
-* [OLMIS-8042](https://openlmis.atlassian.net/browse/OLMIS-8042): Total received quantity column is readonly when requisition is from stock cards. For every program other than TB Monthly
+* [OLMIS-8042](https://openlmis.atlassian.net/browse/OLMIS-8042): Total received quantity column is readonly when requisition is from stock cards For every program other than TB Monthly
+* [OPSD-38](https://openlmis.atlassian.net/browse/OPSD-38): Added back the validation for stock on hand column for report only requisition
 * [OLMIS-8074](https://openlmis.atlassian.net/browse/OLMIS-8074): Changed where the user is redirected after creating an order.
 
 7.0.13 / 2024-10-31

--- a/src/requisition-validation/requisition-validator.factory.js
+++ b/src/requisition-validation/requisition-validator.factory.js
@@ -255,8 +255,7 @@
         }
 
         function shouldSkipValidation(lineItem, column, requisition) {
-            if (lineItem[TEMPLATE_COLUMNS.SKIPPED] || (requisition.reportOnly &&
-                column.name === TEMPLATE_COLUMNS.STOCK_ON_HAND)) {
+            if (lineItem[TEMPLATE_COLUMNS.SKIPPED]) {
                 return true;
             }
 


### PR DESCRIPTION
* Description: For report only requisition 'stock on hand' field was not validated on UI, but was validated on BE. This was confusing for the user.
* The validation was removed in ticket: https://openlmis.atlassian.net/browse/TZUP-274
* Resolving ticket: https://openlmis.atlassian.net/browse/OPSD-38