### PR TITLE
OLMIS-8154: Validation of the Requested quantity explanation column

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 Upcoming Version (WIP)
 ==================
+Bug fixes:
+* [OLMIS-8154](https://openlmis.atlassian.net/browse/OLMIS-8154): Explanation no longer required when requested equals calculated.
 
 7.0.16 / 2026-02-05
 =================

--- a/src/requisition-validation/validation.factory.js
+++ b/src/requisition-validation/validation.factory.js
@@ -94,12 +94,16 @@
                 calculatedOrderQuantityIsaColumn = requisition.template
                     .getColumn(TEMPLATE_COLUMNS.CALCULATED_ORDER_QUANTITY_ISA),
                 requestedQuantityExplanation = lineItem.requestedQuantityExplanation,
-                requestedQuantity = lineItem.requestedQuantity;
+                requestedQuantity = lineItem.requestedQuantity,
+                calculatedValue = isDisplayed(calculatedOrderQuantityColumn)
+                    ? lineItem.calculatedOrderQuantity
+                    : lineItem.calculatedOrderQuantityIsa;
 
             if (!lineItem.isNonFullSupply() &&
                 isDisplayed(requestedQuantityColumn) &&
                 (isDisplayed(calculatedOrderQuantityColumn) || isDisplayed(calculatedOrderQuantityIsaColumn)) &&
                 isFilled(requestedQuantity) &&
+                requestedQuantity !== calculatedValue &&
                 !requestedQuantityExplanation) {
                 return messageService.get('requisitionValidation.required');
             }

--- a/src/requisition-validation/validation.factory.spec.js
+++ b/src/requisition-validation/validation.factory.spec.js
@@ -205,6 +205,15 @@ describe('validationFactory', function() {
                 .toBeUndefined();
         });
 
+        it('should return undefined if requestedQuantity equals calculatedOrderQuantity', function() {
+            lineItem.requestedQuantity = 10;
+            lineItem.calculatedOrderQuantity = 10;
+            lineItem.requestedQuantityExplanation = undefined;
+
+            expect(validationFactory.requestedQuantityExplanation(lineItem, requisitionMock))
+                .toBeUndefined();
+        });
+
     });
 
     describe('requestedQuantity', function() {


### PR DESCRIPTION
Requested quantity explanation is no longer required when Requested quantity equals Calculated order quantity, matching the column header hint.