### PR TITLE
OLMIS-8192: Auto-resize requested quantity explanation cell

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 Upcoming Version (WIP)
 ==================
+Bug fixes:
+* [OLMIS-8192](https://openlmis.atlassian.net/browse/OLMIS-8192): Requested quantity explanation column adjusts width with input.
 
 7.0.16 / 2026-02-05
 =================

--- a/src/requisition-product-grid/product-grid-cell-input-text.html
+++ b/src/requisition-product-grid/product-grid-cell-input-text.html
@@ -1,4 +1,6 @@
-<input type="text"
-	ng-model="lineItem[column.name]"
-	ng-disabled="lineItem.skipped"
-	ng-change="update()" />
+<div class="input-control" input-control>
+	<input type="text"
+		ng-model="lineItem[column.name]"
+		ng-disabled="lineItem.skipped"
+		ng-change="update()" />
+</div>


### PR DESCRIPTION
The Requested quantity explanation column now grows with content as the user types. Requires the matching ui-components change.