### PR TITLE
OLMIS-8127: Validate batch approve field on blur

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Bug fixes:
 * [OLMIS-8191](https://openlmis.atlassian.net/browse/OLMIS-8191): Remarks column editable and size adjustable dynamically.
 >>>>>>> master
 * [OLMIS-8154](https://openlmis.atlassian.net/browse/OLMIS-8154): Explanation no longer required when requested equals calculated.
+* [OLMIS-8127](https://openlmis.atlassian.net/browse/OLMIS-8127): Batch approve now shows validation error immediately when field is cleared and loses focus.
 
 7.0.16 / 2026-02-05
 =================

--- a/src/requisition-batch-approval/validate-requisition.directive.js
+++ b/src/requisition-batch-approval/validate-requisition.directive.js
@@ -60,6 +60,7 @@
             }
 
             ngModelCtrl.$viewChangeListeners.push(validateRequisition);
+            element.on('blur', validateRequisition);
 
             wrapper.on('openlmisInvalid.show', updateMessage);
             wrapper.on('openlmisInvalid.hide', updateMessage);

--- a/src/requisition-batch-approval/validate-requisition.directive.spec.js
+++ b/src/requisition-batch-approval/validate-requisition.directive.spec.js
@@ -127,6 +127,38 @@ describe('validateRequisition directive', function() {
 
     });
 
+    describe('on blur (OLMIS-8127)', function() {
+
+        it('should mark requisition invalid when blank field loses focus', function() {
+            var input = div.find('div:nth-child(1) input');
+
+            input.val('');
+            input.triggerHandler('change');
+            $scope.$apply();
+
+            input.triggerHandler('blur');
+
+            input.parent().trigger('openlmisInvalid.show');
+
+            expect($scope.requisition.$error).not.toBeUndefined();
+        });
+
+        it('should not mark requisition invalid on blur when field is filled', function() {
+            var input = div.find('div:nth-child(1) input');
+
+            input.val(5);
+            input.triggerHandler('change');
+            $scope.$apply();
+
+            input.triggerHandler('blur');
+
+            input.parent().trigger('openlmisInvalid.show');
+
+            expect($scope.requisition.$error).toBeUndefined();
+        });
+
+    });
+
     function compileMarkup(markup) {
         var element = $compile(markup)($scope);
 

--- a/src/requisition-batch-approval/validate-requisition.directive.spec.js
+++ b/src/requisition-batch-approval/validate-requisition.directive.spec.js
@@ -130,29 +130,29 @@ describe('validateRequisition directive', function() {
     describe('on blur (OLMIS-8127)', function() {
 
         it('should mark requisition invalid when blank field loses focus', function() {
-            var input = div.find('div:nth-child(1) input');
-
-            input.val('');
-            input.triggerHandler('change');
+            div.find('div:nth-child(1) input').val('');
+            div.find('div:nth-child(1) input').triggerHandler('change');
             $scope.$apply();
 
-            input.triggerHandler('blur');
+            div.find('div:nth-child(1) input').triggerHandler('blur');
 
-            input.parent().trigger('openlmisInvalid.show');
+            div.find('div:nth-child(1) input')
+                .parent()
+                .trigger('openlmisInvalid.show');
 
             expect($scope.requisition.$error).not.toBeUndefined();
         });
 
         it('should not mark requisition invalid on blur when field is filled', function() {
-            var input = div.find('div:nth-child(1) input');
-
-            input.val(5);
-            input.triggerHandler('change');
+            div.find('div:nth-child(1) input').val(5);
+            div.find('div:nth-child(1) input').triggerHandler('change');
             $scope.$apply();
 
-            input.triggerHandler('blur');
+            div.find('div:nth-child(1) input').triggerHandler('blur');
 
-            input.parent().trigger('openlmisInvalid.show');
+            div.find('div:nth-child(1) input')
+                .parent()
+                .trigger('openlmisInvalid.show');
 
             expect($scope.requisition.$error).toBeUndefined();
         });


### PR DESCRIPTION
Clearing an approved quantity field and clicking away now marks the requisition invalid immediately, without waiting for the Approve button.