### PR TITLE
OLMIS-8180: Show order summary modal quantity in selected unit

### DIFF
--- a/src/requisition-order-create/order-create-summary-modal.jsx
+++ b/src/requisition-order-create/order-create-summary-modal.jsx
@@ -8,8 +8,11 @@ import getService from '../react-components/utils/angular-utils';
 const OrderCreateSummaryModal = ({ isOpen, orders, onSaveClick, onModalClose }) => {
     const { formatMessage } = useMemo(() => getService('messageService'), []);
     const quantityUnitCalculateService = useMemo(() => getService('quantityUnitCalculateService'), []);
-    const columns = useMemo(() => orderTableColumns(true, formatMessage, true, null,
-        quantityUnitCalculateService), []);
+    const localStorageService = useMemo(() => getService('localStorageService'), []);
+    const QUANTITY_UNIT = useMemo(() => getService('QUANTITY_UNIT'), []);
+    const showInDoses = (localStorageService.get('quantityUnit') || QUANTITY_UNIT.DOSES) === QUANTITY_UNIT.DOSES;
+    const columns = useMemo(() => orderTableColumns(true, formatMessage, showInDoses, null,
+        quantityUnitCalculateService), [showInDoses]);
     const [currentTab, setCurrentTab] = useState(0);
 
     return (


### PR DESCRIPTION
The order create summary modal now displays quantities in the unit selected on the toggle, instead of always in doses.