### PR TITLE
OLMIS-8177: Remove unused validation class binding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 7.0.18-SNAPSHOT (WIP)
 ==================
 
+Bug fixes:
+* [OLMIS-8177](https://openlmis.atlassian.net/browse/OLMIS-8177): Removed a dead validation class binding from the requisition product grid packs/doses quantity input.
+
 7.0.17 / 2026-06-09
 ==================
 Bug fixes:

--- a/src/requisition-product-grid/product-grid-cell-input-numeric.html
+++ b/src/requisition-product-grid/product-grid-cell-input-numeric.html
@@ -9,5 +9,4 @@
     show-in-doses="showInDoses()"
     item="lineItem.quantities[column.name]"
     net-content="lineItem.orderable.netContent"
-    on-change-quantity="update()"
-    input-class="{'error': lineItem.quantityInvalid}"/>
+    on-change-quantity="update()"/>


### PR DESCRIPTION
Removes a dead validation class binding from the requisition product grid quantity input; validation already runs through the shared error directive.