### PR TITLE
OLMIS-8244: Show packs-to-order hint on order create

### DIFF
--- a/src/requisition-order-create/order-create-table-helper-functions.jsx
+++ b/src/requisition-order-create/order-create-table-helper-functions.jsx
@@ -52,6 +52,8 @@ export const getUpdatedOrder = (selectedOrderable, order) => {
         versionNumber: selectedOrderable.meta.versionNumber,
       },
       netContent: selectedOrderable.netContent,
+      packRoundingThreshold: selectedOrderable.packRoundingThreshold,
+      roundToZero: selectedOrderable.roundToZero,
     },
   };
 

--- a/src/requisition-order-create/order-create.constant.jsx
+++ b/src/requisition-order-create/order-create.constant.jsx
@@ -63,6 +63,7 @@ const orderTableDefaultColumns = (
             showInDoses={showInDoses}
             item={rowData}
             onChangeQuantity={handleQuantityChange}
+            showPacksToOrderHint
             numeric
             key={`quantity-input-${rowData.orderable?.id}`}
           />
@@ -127,6 +128,7 @@ const orderReadonlyTableColumns = (
           item={rowData}
           onChangeQuantity={() => {}}
           disabled={true}
+          showPacksToOrderHint
           numeric
           key={`readonly-quantity-input-${rowData.orderable?.id}`}
         />


### PR DESCRIPTION
## OLMIS-8244 — Show packs-to-order preview on Create Order

https://openlmis.atlassian.net/browse/OLMIS-8244

Wires up the "Will be ordered as X pack(s)" preview on the requisition-less **Create Order** screen.
Companion to:
- [OpenLMIS/openlmis-fulfillment#55](https://github.com/OpenLMIS/openlmis-fulfillment/pull/55) — backend converts doses → packs at send.
- [OpenLMIS/openlmis-ui-components#85](https://github.com/OpenLMIS/openlmis-ui-components/pull/85) — the hint component + `packsToOrder` JS port.

### Change
- `order-create.constant.jsx` — enable `showPacksToOrderHint` on the quantity `QuantityUnitInput`
  in both the editable and the read-only (order summary) columns.
- `order-create-table-helper-functions.jsx` — include `packRoundingThreshold` and `roundToZero` on
  the line orderable so the hint can compute the rounded pack count (no extra fetch — both fields are
  already delivered with the stock-summary orderable; they were only being dropped by the slim rebuild).

### E2E verified (live)
Preview shows the correct rounded packs while entering quantities and in the Orders Summary
confirmation modal; the draft stays in doses (status CREATING, `orderedQuantity` unconverted) and is
converted only on send.
